### PR TITLE
package names support

### DIFF
--- a/kotlin
+++ b/kotlin
@@ -89,7 +89,12 @@ while [ $# -gt 0 ]; do
       if [ "" = "$cmd" ]; then
         cmd="$1"
         if [ -f "$cmd" ]; then
-            kotlin_args=("${kotlin_args[@]}" "namespace")
+            namespace="namespace"
+            package=`grep package $cmd | awk '{print $2}'`
+            if [ -n "$package" ]; then
+                namespace="$package.$namespace"
+            fi
+            kotlin_args=("${kotlin_args[@]}" $namespace)
         else
             kotlin_args=("${kotlin_args[@]}" "$1")
         fi 


### PR DESCRIPTION
If script has package name it will not run as it cannot find correct namespace, this fix will prepend "namespace" with package name
