### PR TITLE
support new (required) Preloader option: time|notime

### DIFF
--- a/kotlin
+++ b/kotlin
@@ -65,6 +65,7 @@ declare -a kotlin_args
 
 cmd=""
 scriptCp=""
+profile_preloader="notime"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -80,10 +81,14 @@ while [ $# -gt 0 ]; do
       shift 2
       ;;
     -J*)
-      # as with -D, pass to scala even though it will almost
+      # as with -D, pass to kotlin even though it will almost
       # never be used.
       java_args=("${java_args[@]}" "${1:2}")
       # kotlin_args=("${kotlin_args[@]}" "$1")
+      shift
+      ;;
+    -pp)
+      profile_preloader="time"
       shift
       ;;
     *)
@@ -104,7 +109,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "" = "$cmd" ]; then
-    echo "Usage: kotlin [-cp <classpath>] <script|source|module|className> [args...]"
+    echo "Usage: kotlin [-cp <classpath>] [-pp] <script|source|module|className> [args...]"
     exit 1
 fi
 
@@ -176,8 +181,8 @@ if [ -f "$cmd" ]; then
 
         set -e
         mkdir -p "$jarDir"
-        # echo kotlinc-jvm -module "$(nativePath "$module")" -jar "$(nativePath "$jar")"
-        kotlinc-jvm -module "$(nativePath "$module")" -jar "$(nativePath "$jar")"
+        # echo kotlinc-jvm $profile_preloader -module "$(nativePath "$module")" -jar "$(nativePath "$jar")"
+        kotlinc-jvm $profile_preloader -module "$(nativePath "$module")" -jar "$(nativePath "$jar")"
     fi
 fi
 


### PR DESCRIPTION
This is required to support the latest version of kotlinc-jvm. See [here](http://devnet.jetbrains.com/thread/444344) for more details.

Note: the "notime" option [doesn't currently disable profiling](https://github.com/JetBrains/kotlin/commit/2f65506d765925a6a6d552e5c2b8a280f7cf3ed2#commitcomment-3157563), but it looks like this will be fixed shortly.
